### PR TITLE
DEV - changing json structure

### DIFF
--- a/components/endpoints/src/main/java/io/collective/endpoints/EndpointWorker.java
+++ b/components/endpoints/src/main/java/io/collective/endpoints/EndpointWorker.java
@@ -44,8 +44,7 @@ public class EndpointWorker implements Worker<EndpointTask> {
                 JsonMapper mapper = new JsonMapper();
                 mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
                 Json json = mapper.readValue(response, Json.class);
-                Networks networks = json.getNetworks();
-                for (Item item : networks.getItems()) {
+                for (Item item : json.getNetworks()) {
                     // TODO fix orgId
                     gateway.save(new BigInteger(item.getStartAddress()), new BigInteger(item.getEndAddress()), 1);
                 }

--- a/components/json-support/src/main/java/io/collective/json/Json.java
+++ b/components/json-support/src/main/java/io/collective/json/Json.java
@@ -3,13 +3,15 @@ package io.collective.json;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Json {
     @JsonProperty
-    private Networks networks;
+    private List<Item> networks;
 
-    public Networks getNetworks() {
+    public List<Item> getNetworks() {
         return networks;
     }
 }

--- a/components/json-support/src/test/java/test/collective/json/JsonTest.java
+++ b/components/json-support/src/test/java/test/collective/json/JsonTest.java
@@ -2,11 +2,13 @@ package test.collective.json;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.collective.json.Item;
 import io.collective.json.Json;
 import io.collective.json.Networks;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -20,7 +22,7 @@ public class JsonTest {
         JsonMapper mapper = new JsonMapper();
         mapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         Json json = mapper.readValue(jsonString, Json.class);
-        Networks networks = json.getNetworks();
-        assertEquals(229, networks.getItems().size());
+        List<Item> networks = json.getNetworks();
+        assertEquals(229, networks.size());
     }
 }


### PR DESCRIPTION
Small change to JSON structure.

The `Networks` class is no longer used; instead the parent `Json` class uses a List of `Item`s to represent individual networks.